### PR TITLE
Fix Admin-register error: Access Denied

### DIFF
--- a/admin-register.php
+++ b/admin-register.php
@@ -1,12 +1,3 @@
-<?php
-    session_start();
-    if(!isset($_SESSION["adminvalid"]) || $_SESSION["adminvalid"]!="true")
-    {
-        echo("<script type='text/javascript'>alert('Access Denied'); </script>");
-        header('Refresh: 0; URL = admin-login.html');
-    }
-?>
-
 <!-- Load dbconnect -->
 <?php
     include_once('sql/dbconnect.php');


### PR DESCRIPTION
The page checked if session variable is set for the admin to access it,
which is a requirement for all admin pages to be accessed (except login/register)
Removing the session validation code solves the problem